### PR TITLE
Introduce graphing API and engine with sampling, caching, and GUI entrypoint

### DIFF
--- a/src/main/java/com/mlprograms/justmath/Main.java
+++ b/src/main/java/com/mlprograms/justmath/Main.java
@@ -24,31 +24,46 @@
 
 package com.mlprograms.justmath;
 
-import com.mlprograms.justmath.converter.Unit;
-import com.mlprograms.justmath.converter.UnitConverter;
-import com.mlprograms.justmath.converter.UnitValue;
 import com.mlprograms.justmath.graphfx.planar.view.GraphFxViewer;
 
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Quick start entry point for launching GraphFx visually.
+ * <p>
+ * Usage examples:
+ * <ul>
+ *     <li>No args: starts with a demo set of expressions.</li>
+ *     <li>With args: each argument is interpreted as one expression, e.g. {@code x^2} {@code sin(x)}.</li>
+ * </ul>
+ */
 public class Main {
 
+    private static final List<String> DEFAULT_EXPRESSIONS = List.of("x^2", "sin(x)", "x^3-2*x");
+
     public static void main(final String[] args) {
+        final List<String> expressions = resolveExpressions(args);
 
-//        UnitConverter unitConverter = new UnitConverter();
-//
-//        BigNumber convertedToBigNumber = unitConverter.convertToBigNumber("1", Unit.Area.ACRE, Unit.Area.SQUARE_KILOMETER);
-//        UnitValue convertedToUnitValue = unitConverter.convert("1", Unit.Area.ACRE, Unit.Area.SQUARE_KILOMETER);
-//
-//        System.out.println(convertedToBigNumber);
-//        System.out.println(convertedToUnitValue.getValue());
+        final GraphFxViewer viewer = new GraphFxViewer("JustMath Graphing Calculator");
 
-        final UnitValue unitValue = new UnitValue("12L");
-        System.out.println(new UnitConverter().convertToBigNumber(unitValue, Unit.Volume.DROP));
+        for (String expression : expressions) {
+            viewer.plotExpression(expression);
+        }
 
-        GraphFxViewer viewer = new GraphFxViewer("Test");
-        viewer.plotExpression("x^2");
         viewer.show();
+        System.out.println("GraphFx started. Plotted expressions: " + String.join(", ", expressions));
+    }
 
+    private static List<String> resolveExpressions(final String[] args) {
+        if (args == null || args.length == 0) {
+            return DEFAULT_EXPRESSIONS;
+        }
 
+        return Arrays.stream(args)
+                .map(String::trim)
+                .filter(expression -> !expression.isBlank())
+                .toList();
     }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphing/api/CompiledPlotExpression.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/CompiledPlotExpression.java
@@ -1,0 +1,11 @@
+package com.mlprograms.justmath.graphing.api;
+
+import com.mlprograms.justmath.graphing.engine.EvaluationContext;
+
+/**
+ * Compiled, reusable plotting expression.
+ */
+public interface CompiledPlotExpression {
+
+    double evaluate(double x, EvaluationContext context);
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/Domain.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/Domain.java
@@ -1,0 +1,13 @@
+package com.mlprograms.justmath.graphing.api;
+
+/**
+ * Inclusive plotting domain for x-values.
+ */
+public record Domain(double minX, double maxX) {
+
+    public Domain {
+        if (Double.isNaN(minX) || Double.isNaN(maxX) || minX >= maxX) {
+            throw new IllegalArgumentException("Invalid domain");
+        }
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/GraphingCalculator.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/GraphingCalculator.java
@@ -1,0 +1,16 @@
+package com.mlprograms.justmath.graphing.api;
+
+import java.util.List;
+
+public interface GraphingCalculator {
+
+    PlotResponse plot(String expression, Domain domain, Resolution resolution);
+
+    PlotResponse plot(PlotRequest request);
+
+    List<PlotSeries> plotAll(List<PlotRequest> requests);
+
+    CompiledPlotExpression compile(String expression);
+
+    PlotSeries sample(CompiledPlotExpression expression, PlotRequest request);
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/GraphingCalculators.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/GraphingCalculators.java
@@ -1,0 +1,16 @@
+package com.mlprograms.justmath.graphing.api;
+
+import com.mlprograms.justmath.graphing.engine.DefaultGraphingCalculator;
+
+/**
+ * Factory for graphing calculators.
+ */
+public final class GraphingCalculators {
+
+    private GraphingCalculators() {
+    }
+
+    public static GraphingCalculator createDefault() {
+        return new DefaultGraphingCalculator();
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/GraphingEvaluationException.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/GraphingEvaluationException.java
@@ -1,0 +1,8 @@
+package com.mlprograms.justmath.graphing.api;
+
+public class GraphingEvaluationException extends GraphingException {
+
+    public GraphingEvaluationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/GraphingException.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/GraphingException.java
@@ -1,0 +1,15 @@
+package com.mlprograms.justmath.graphing.api;
+
+/**
+ * Base unchecked exception for graphing failures.
+ */
+public class GraphingException extends RuntimeException {
+
+    public GraphingException(final String message) {
+        super(message);
+    }
+
+    public GraphingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/GraphingParseException.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/GraphingParseException.java
@@ -1,0 +1,8 @@
+package com.mlprograms.justmath.graphing.api;
+
+public class GraphingParseException extends GraphingException {
+
+    public GraphingParseException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/PlotRequest.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/PlotRequest.java
@@ -1,0 +1,90 @@
+package com.mlprograms.justmath.graphing.api;
+
+import com.mlprograms.justmath.graphing.engine.sampling.SamplingStrategies;
+import com.mlprograms.justmath.graphing.engine.sampling.SamplingStrategy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Plot request configuration object.
+ */
+public final class PlotRequest {
+
+    private final String expression;
+    private final Domain domain;
+    private final Resolution resolution;
+    private final SamplingStrategy samplingStrategy;
+    private final Map<String, Double> variables;
+
+    private PlotRequest(final Builder builder) {
+        this.expression = builder.expression;
+        this.domain = builder.domain;
+        this.resolution = builder.resolution;
+        this.samplingStrategy = builder.samplingStrategy;
+        this.variables = Collections.unmodifiableMap(new HashMap<>(builder.variables));
+    }
+
+    public String expression() {
+        return expression;
+    }
+
+    public Domain domain() {
+        return domain;
+    }
+
+    public Resolution resolution() {
+        return resolution;
+    }
+
+    public SamplingStrategy samplingStrategy() {
+        return samplingStrategy;
+    }
+
+    public Map<String, Double> variables() {
+        return variables;
+    }
+
+    public static final class Builder {
+        private final String expression;
+        private Domain domain = new Domain(-10.0d, 10.0d);
+        private Resolution resolution = Resolution.fixed(500);
+        private SamplingStrategy samplingStrategy = SamplingStrategies.uniform();
+        private Map<String, Double> variables = Map.of();
+
+        public Builder(final String expression) {
+            if (expression == null || expression.isBlank()) {
+                throw new IllegalArgumentException("expression must not be blank");
+            }
+            this.expression = expression;
+        }
+
+        public Builder domain(final Domain domain) {
+            this.domain = domain;
+            return this;
+        }
+
+        public Builder resolution(final Resolution resolution) {
+            this.resolution = resolution;
+            return this;
+        }
+
+        public Builder samplingStrategy(final SamplingStrategy samplingStrategy) {
+            this.samplingStrategy = samplingStrategy;
+            return this;
+        }
+
+        public Builder variables(final Map<String, Double> variables) {
+            this.variables = variables;
+            return this;
+        }
+
+        public PlotRequest build() {
+            if (domain == null || resolution == null || samplingStrategy == null || variables == null) {
+                throw new IllegalStateException("domain, resolution, samplingStrategy and variables must not be null");
+            }
+            return new PlotRequest(this);
+        }
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/PlotResponse.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/PlotResponse.java
@@ -1,0 +1,18 @@
+package com.mlprograms.justmath.graphing.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result container for one or more plotted expressions.
+ */
+public record PlotResponse(List<PlotSeries> series) {
+
+    public PlotResponse {
+        if (series == null) {
+            throw new IllegalArgumentException("series must not be null");
+        }
+        series = Collections.unmodifiableList(new ArrayList<>(series));
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/PlotSeries.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/PlotSeries.java
@@ -1,0 +1,20 @@
+package com.mlprograms.justmath.graphing.api;
+
+import java.util.Arrays;
+
+/**
+ * Immutable sampled point series.
+ */
+public record PlotSeries(String expression, double[] xValues, double[] yValues) {
+
+    public PlotSeries {
+        if (expression == null || expression.isBlank()) {
+            throw new IllegalArgumentException("expression must not be blank");
+        }
+        if (xValues == null || yValues == null || xValues.length != yValues.length) {
+            throw new IllegalArgumentException("xValues/yValues must be non-null and same length");
+        }
+        xValues = Arrays.copyOf(xValues, xValues.length);
+        yValues = Arrays.copyOf(yValues, yValues.length);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/api/Resolution.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/api/Resolution.java
@@ -1,0 +1,30 @@
+package com.mlprograms.justmath.graphing.api;
+
+/**
+ * Sampling resolution for plotting.
+ */
+public record Resolution(int targetSamples, double pixelWidthHint) {
+
+    public Resolution {
+        if (targetSamples < 2) {
+            throw new IllegalArgumentException("targetSamples must be >= 2");
+        }
+        if (Double.isNaN(pixelWidthHint) || pixelWidthHint <= 0.0d) {
+            throw new IllegalArgumentException("pixelWidthHint must be > 0");
+        }
+    }
+
+    public static Resolution forPixels(final int widthPx) {
+        if (widthPx < 2) {
+            throw new IllegalArgumentException("widthPx must be >= 2");
+        }
+        return new Resolution(Math.max(2, widthPx), widthPx);
+    }
+
+    public static Resolution fixed(final int samples) {
+        if (samples < 2) {
+            throw new IllegalArgumentException("samples must be >= 2");
+        }
+        return new Resolution(samples, samples);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultExpressionCompiler.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultExpressionCompiler.java
@@ -1,0 +1,48 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import com.mlprograms.justmath.calculator.CalculatorEngine;
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+import com.mlprograms.justmath.graphing.api.GraphingEvaluationException;
+import com.mlprograms.justmath.graphing.api.GraphingParseException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Compiler facade that validates expression syntax and creates a reusable evaluator.
+ */
+public final class DefaultExpressionCompiler implements ExpressionCompiler {
+
+    private final CalculatorEngine calculatorEngine;
+
+    public DefaultExpressionCompiler(final CalculatorEngine calculatorEngine) {
+        this.calculatorEngine = calculatorEngine;
+    }
+
+    @Override
+    public CompiledPlotExpression compile(final String expression) {
+        if (expression == null || expression.isBlank()) {
+            throw new GraphingParseException("Expression must not be blank", null);
+        }
+
+        try {
+            calculatorEngine.evaluate(expression, Map.of("x", "0"));
+        } catch (Exception exception) {
+            throw new GraphingParseException("Failed to parse expression: " + expression, exception);
+        }
+
+        return (x, context) -> {
+            final Map<String, String> mappedVariables = new HashMap<>();
+            for (Map.Entry<String, Double> entry : context.variables().entrySet()) {
+                mappedVariables.put(entry.getKey(), Double.toString(entry.getValue()));
+            }
+            mappedVariables.put("x", Double.toString(x));
+
+            try {
+                return calculatorEngine.evaluate(expression, mappedVariables).doubleValue();
+            } catch (Exception exception) {
+                throw new GraphingEvaluationException("Failed evaluating expression at x=" + x, exception);
+            }
+        };
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultGraphingCalculator.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultGraphingCalculator.java
@@ -1,0 +1,68 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import com.mlprograms.justmath.calculator.CalculatorEngine;
+import com.mlprograms.justmath.graphing.api.*;
+import com.mlprograms.justmath.graphing.engine.cache.ExpressionCache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Default graphing calculator implementation for headless and GUI adapters.
+ */
+public final class DefaultGraphingCalculator implements GraphingCalculator {
+
+    private final ExpressionCompiler compiler;
+    private final SamplingEngine samplingEngine;
+    private final ExpressionCache expressionCache;
+
+    public DefaultGraphingCalculator() {
+        this(new DefaultExpressionCompiler(new CalculatorEngine()), new DefaultSamplingEngine(), new ExpressionCache(512));
+    }
+
+    public DefaultGraphingCalculator(final ExpressionCompiler compiler,
+                                     final SamplingEngine samplingEngine,
+                                     final ExpressionCache expressionCache) {
+        this.compiler = Objects.requireNonNull(compiler, "compiler");
+        this.samplingEngine = Objects.requireNonNull(samplingEngine, "samplingEngine");
+        this.expressionCache = Objects.requireNonNull(expressionCache, "expressionCache");
+    }
+
+    @Override
+    public PlotResponse plot(final String expression, final Domain domain, final Resolution resolution) {
+        return plot(new PlotRequest.Builder(expression).domain(domain).resolution(resolution).build());
+    }
+
+    @Override
+    public PlotResponse plot(final PlotRequest request) {
+        final CompiledPlotExpression expression = compile(request.expression());
+        return new PlotResponse(List.of(sample(expression, request)));
+    }
+
+    @Override
+    public List<PlotSeries> plotAll(final List<PlotRequest> requests) {
+        final List<PlotSeries> result = new ArrayList<>(requests.size());
+        for (PlotRequest request : requests) {
+            result.add(plot(request).series().getFirst());
+        }
+        return result;
+    }
+
+    @Override
+    public CompiledPlotExpression compile(final String expression) {
+        final CompiledPlotExpression cached = expressionCache.get(expression);
+        if (cached != null) {
+            return cached;
+        }
+
+        final CompiledPlotExpression compiledExpression = compiler.compile(expression);
+        expressionCache.put(expression, compiledExpression);
+        return compiledExpression;
+    }
+
+    @Override
+    public PlotSeries sample(final CompiledPlotExpression expression, final PlotRequest request) {
+        return samplingEngine.sample(expression, request);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultSamplingEngine.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/DefaultSamplingEngine.java
@@ -1,0 +1,22 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+import com.mlprograms.justmath.graphing.api.PlotRequest;
+import com.mlprograms.justmath.graphing.api.PlotSeries;
+import com.mlprograms.justmath.graphing.model.PointBuffer;
+
+/**
+ * Sampling engine delegating to request-level strategies.
+ */
+public final class DefaultSamplingEngine implements SamplingEngine {
+
+    @Override
+    public PlotSeries sample(final CompiledPlotExpression expression, final PlotRequest request) {
+        final EvaluationContext context = new EvaluationContext();
+        context.putAll(request.variables());
+        final PointBuffer points = request.samplingStrategy()
+                .sample(expression, request.domain(), request.resolution(), context);
+
+        return new PlotSeries(request.expression(), points.xValues(), points.yValues());
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/EvaluationContext.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/EvaluationContext.java
@@ -1,0 +1,24 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mutable evaluation context reused while sampling points.
+ */
+public final class EvaluationContext {
+
+    private final Map<String, Double> variables = new HashMap<>();
+
+    public void clear() {
+        variables.clear();
+    }
+
+    public void putAll(final Map<String, Double> values) {
+        variables.putAll(values);
+    }
+
+    public Map<String, Double> variables() {
+        return variables;
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/ExpressionCompiler.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/ExpressionCompiler.java
@@ -1,0 +1,8 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+
+public interface ExpressionCompiler {
+
+    CompiledPlotExpression compile(String expression);
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/SamplingEngine.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/SamplingEngine.java
@@ -1,0 +1,10 @@
+package com.mlprograms.justmath.graphing.engine;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+import com.mlprograms.justmath.graphing.api.PlotRequest;
+import com.mlprograms.justmath.graphing.api.PlotSeries;
+
+public interface SamplingEngine {
+
+    PlotSeries sample(CompiledPlotExpression expression, PlotRequest request);
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/cache/ExpressionCache.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/cache/ExpressionCache.java
@@ -1,0 +1,31 @@
+package com.mlprograms.justmath.graphing.engine.cache;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Small LRU cache for compiled expressions.
+ */
+public final class ExpressionCache {
+
+    private final Map<String, CompiledPlotExpression> cache;
+
+    public ExpressionCache(final int maxSize) {
+        this.cache = new LinkedHashMap<>(32, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(final Map.Entry<String, CompiledPlotExpression> eldest) {
+                return size() > maxSize;
+            }
+        };
+    }
+
+    public synchronized CompiledPlotExpression get(final String expression) {
+        return cache.get(expression);
+    }
+
+    public synchronized void put(final String expression, final CompiledPlotExpression compiledExpression) {
+        cache.put(expression, compiledExpression);
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/SamplingStrategies.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/SamplingStrategies.java
@@ -1,0 +1,13 @@
+package com.mlprograms.justmath.graphing.engine.sampling;
+
+public final class SamplingStrategies {
+
+    private static final SamplingStrategy UNIFORM = new UniformSampler();
+
+    private SamplingStrategies() {
+    }
+
+    public static SamplingStrategy uniform() {
+        return UNIFORM;
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/SamplingStrategy.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/SamplingStrategy.java
@@ -1,0 +1,12 @@
+package com.mlprograms.justmath.graphing.engine.sampling;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+import com.mlprograms.justmath.graphing.api.Domain;
+import com.mlprograms.justmath.graphing.api.Resolution;
+import com.mlprograms.justmath.graphing.engine.EvaluationContext;
+import com.mlprograms.justmath.graphing.model.PointBuffer;
+
+public interface SamplingStrategy {
+
+    PointBuffer sample(CompiledPlotExpression expression, Domain domain, Resolution resolution, EvaluationContext context);
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/UniformSampler.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/engine/sampling/UniformSampler.java
@@ -1,0 +1,31 @@
+package com.mlprograms.justmath.graphing.engine.sampling;
+
+import com.mlprograms.justmath.graphing.api.CompiledPlotExpression;
+import com.mlprograms.justmath.graphing.api.Domain;
+import com.mlprograms.justmath.graphing.api.Resolution;
+import com.mlprograms.justmath.graphing.engine.EvaluationContext;
+import com.mlprograms.justmath.graphing.model.PointBuffer;
+
+/**
+ * Uniform x-axis sampler with fixed step width.
+ */
+public final class UniformSampler implements SamplingStrategy {
+
+    @Override
+    public PointBuffer sample(final CompiledPlotExpression expression, final Domain domain,
+                              final Resolution resolution, final EvaluationContext context) {
+        final int samples = resolution.targetSamples();
+        final PointBuffer buffer = new PointBuffer(samples);
+
+        final double span = domain.maxX() - domain.minX();
+        final double step = span / (samples - 1.0d);
+
+        for (int index = 0; index < samples; index++) {
+            final double x = domain.minX() + index * step;
+            final double y = expression.evaluate(x, context);
+            buffer.add(x, y);
+        }
+
+        return buffer;
+    }
+}

--- a/src/main/java/com/mlprograms/justmath/graphing/model/PointBuffer.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/model/PointBuffer.java
@@ -1,0 +1,32 @@
+package com.mlprograms.justmath.graphing.model;
+
+import java.util.Arrays;
+
+/**
+ * Primitive storage for sampled points.
+ */
+public final class PointBuffer {
+
+    private final double[] xValues;
+    private final double[] yValues;
+    private int size;
+
+    public PointBuffer(final int capacity) {
+        this.xValues = new double[capacity];
+        this.yValues = new double[capacity];
+    }
+
+    public void add(final double x, final double y) {
+        xValues[size] = x;
+        yValues[size] = y;
+        size++;
+    }
+
+    public double[] xValues() {
+        return Arrays.copyOf(xValues, size);
+    }
+
+    public double[] yValues() {
+        return Arrays.copyOf(yValues, size);
+    }
+}

--- a/src/test/java/com/mlprograms/justmath/graphing/DefaultGraphingCalculatorTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphing/DefaultGraphingCalculatorTest.java
@@ -1,0 +1,29 @@
+package com.mlprograms.justmath.graphing;
+
+import com.mlprograms.justmath.graphing.api.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultGraphingCalculatorTest {
+
+    @Test
+    void shouldSampleQuadraticFunction() {
+        GraphingCalculator calculator = GraphingCalculators.createDefault();
+
+        PlotResponse response = calculator.plot("x^2", new Domain(-2.0d, 2.0d), Resolution.fixed(5));
+
+        PlotSeries series = response.series().getFirst();
+        assertEquals(5, series.xValues().length);
+        assertEquals(-2.0d, series.xValues()[0], 1e-10);
+        assertEquals(4.0d, series.yValues()[0], 1e-10);
+        assertEquals(0.0d, series.yValues()[2], 1e-10);
+        assertEquals(4.0d, series.yValues()[4], 1e-10);
+    }
+
+    @Test
+    void shouldRejectInvalidDomain() {
+        assertThrows(IllegalArgumentException.class, () -> new Domain(1.0d, 1.0d));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a stable, reusable graphing API and engine to sample and evaluate mathematical expressions for plotting.
- Support compiling expressions once and reusing compiled evaluators during sampling to improve performance.
- Add basic sampling strategies and an LRU cache for compiled expressions to optimize repeated plotting. 
- Expose a simple visual entry point to plot multiple expressions from the command line.

### Description

- Added a new graphing API surface including `CompiledPlotExpression`, `Domain`, `Resolution`, `PlotRequest`, `PlotResponse`, `PlotSeries`, `GraphingCalculator` and related exceptions. 
- Implemented default engine components: `DefaultGraphingCalculator`, `DefaultExpressionCompiler` (backed by `CalculatorEngine`), `DefaultSamplingEngine`, `UniformSampler`, and `ExpressionCache` for LRU caching. 
- Introduced sampling infrastructure and utilities: `SamplingStrategy`, `SamplingStrategies`, `SamplingEngine`, `EvaluationContext`, and `PointBuffer` for primitive point storage. 
- Updated `Main` to provide a GUI quick-start (`GraphFxViewer`) that accepts command-line expressions or uses a demo set and plots them on startup. 

### Testing

- Added unit tests in `src/test/java/.../DefaultGraphingCalculatorTest.java` that validate sampling of a quadratic and domain validation via `Domain`. 
- Ran the new unit tests (`DefaultGraphingCalculatorTest`) and they passed successfully. 
- No other automated tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d7b1c9f88333abb8fb246ed4532e)