### PR TITLE
Refactor: Move GraphFx classes into graphing.fx package structure

### DIFF
--- a/src/main/java/com/mlprograms/justmath/Main.java
+++ b/src/main/java/com/mlprograms/justmath/Main.java
@@ -24,7 +24,7 @@
 
 package com.mlprograms.justmath;
 
-import com.mlprograms.justmath.graphfx.planar.view.GraphFxViewer;
+import com.mlprograms.justmath.graphing.fx.planar.view.GraphFxViewer;
 
 import java.util.List;
 

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/JavaFxRuntime.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/JavaFxRuntime.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx;
+package com.mlprograms.justmath.graphing.fx;
 
 import javafx.application.Platform;
 

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/ReservedVariables.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/ReservedVariables.java
@@ -22,7 +22,23 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx;
 
-record VisibleWorldBounds(double minX, double maxX, double minY, double maxY) {
+import java.util.Objects;
+
+public enum ReservedVariables {
+
+    X("x"),
+    Y("y");
+
+    private final String value;
+
+    ReservedVariables(final String value) {
+        this.value = Objects.requireNonNull(value, "value must not be null");
+    }
+
+    public String getValue() {
+        return value;
+    }
+
 }

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/WindowConfig.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/WindowConfig.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx;
+package com.mlprograms.justmath.graphing.fx;
 
 public record WindowConfig(String title, int width, int height, boolean exitApplicationOnLastViewerClose) {
 

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/calculator/GraphFxCalculatorEngine.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/calculator/GraphFxCalculatorEngine.java
@@ -22,16 +22,16 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.calculator;
+package com.mlprograms.justmath.graphing.fx.planar.calculator;
 
 import com.mlprograms.justmath.bignumber.BigNumber;
 import com.mlprograms.justmath.calculator.CalculatorEngine;
 import com.mlprograms.justmath.calculator.internal.TrigonometricMode;
-import com.mlprograms.justmath.graphfx.ReservedVariables;
-import com.mlprograms.justmath.graphfx.planar.model.PlotLine;
-import com.mlprograms.justmath.graphfx.planar.model.PlotPoint;
-import com.mlprograms.justmath.graphfx.planar.model.PlotResult;
-import com.mlprograms.justmath.graphfx.planar.view.ViewportSnapshot;
+import com.mlprograms.justmath.graphing.fx.ReservedVariables;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotLine;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotPoint;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotResult;
+import com.mlprograms.justmath.graphing.fx.planar.view.ViewportSnapshot;
 
 import java.math.MathContext;
 import java.math.RoundingMode;

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/calculator/GraphFxCalculatorEngineUtils.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/calculator/GraphFxCalculatorEngineUtils.java
@@ -22,12 +22,12 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.calculator;
+package com.mlprograms.justmath.graphing.fx.planar.calculator;
 
 import com.mlprograms.justmath.calculator.CalculatorEngineUtils;
 import com.mlprograms.justmath.calculator.Tokenizer;
 import com.mlprograms.justmath.calculator.internal.Token;
-import com.mlprograms.justmath.graphfx.ReservedVariables;
+import com.mlprograms.justmath.graphing.fx.ReservedVariables;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotLine.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026 Max Lemberg
+ * Copyright (c) 2026 Max Lemberg
  *
  * This file is part of JustMath.
  *
@@ -22,10 +22,15 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx.planar.model;
 
-class GridPaneTest {
+import java.util.List;
+import java.util.Objects;
 
-    // TODO
+public record PlotLine(List<PlotPoint> plotPoints) {
+
+    public PlotLine {
+        Objects.requireNonNull(plotPoints, "plotPoints must not be null");
+    }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotPoint.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026 Max Lemberg
+ * Copyright (c) 2026 Max Lemberg
  *
  * This file is part of JustMath.
  *
@@ -22,10 +22,17 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx;
+package com.mlprograms.justmath.graphing.fx.planar.model;
 
-class JavaFxRuntimeTest {
+import com.mlprograms.justmath.bignumber.BigNumber;
 
-    // TODO
+import java.util.Objects;
+
+public record PlotPoint(BigNumber x, BigNumber y) {
+
+    public PlotPoint {
+        Objects.requireNonNull(x, "x must not be null");
+        Objects.requireNonNull(y, "y must not be null");
+    }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotResult.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/model/PlotResult.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.model;
+package com.mlprograms.justmath.graphing.fx.planar.model;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/GraphFxViewer.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/GraphFxViewer.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
 import com.mlprograms.justmath.bignumber.BigNumber;
 import com.mlprograms.justmath.graphing.api.Domain;
@@ -31,12 +31,12 @@ import com.mlprograms.justmath.graphing.api.GraphingCalculators;
 import com.mlprograms.justmath.graphing.api.PlotRequest;
 import com.mlprograms.justmath.graphing.api.PlotSeries;
 import com.mlprograms.justmath.graphing.api.Resolution;
-import com.mlprograms.justmath.graphfx.JavaFxRuntime;
-import com.mlprograms.justmath.graphfx.WindowConfig;
-import com.mlprograms.justmath.graphfx.planar.calculator.GraphFxCalculatorEngine;
-import com.mlprograms.justmath.graphfx.planar.model.PlotLine;
-import com.mlprograms.justmath.graphfx.planar.model.PlotPoint;
-import com.mlprograms.justmath.graphfx.planar.model.PlotResult;
+import com.mlprograms.justmath.graphing.fx.JavaFxRuntime;
+import com.mlprograms.justmath.graphing.fx.WindowConfig;
+import com.mlprograms.justmath.graphing.fx.planar.calculator.GraphFxCalculatorEngine;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotLine;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotPoint;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotResult;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/GridPane.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/GridPane.java
@@ -22,12 +22,12 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
 import com.mlprograms.justmath.bignumber.BigNumber;
-import com.mlprograms.justmath.graphfx.planar.model.PlotLine;
-import com.mlprograms.justmath.graphfx.planar.model.PlotPoint;
-import com.mlprograms.justmath.graphfx.planar.model.PlotResult;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotLine;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotPoint;
+import com.mlprograms.justmath.graphing.fx.planar.model.PlotResult;
 import javafx.geometry.Point2D;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/ViewportSnapshot.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/ViewportSnapshot.java
@@ -22,17 +22,20 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.model;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
 import com.mlprograms.justmath.bignumber.BigNumber;
 
 import java.util.Objects;
 
-public record PlotPoint(BigNumber x, BigNumber y) {
+public record ViewportSnapshot(BigNumber minX, BigNumber maxX, BigNumber minY, BigNumber maxY, BigNumber cellSize) {
 
-    public PlotPoint {
-        Objects.requireNonNull(x, "x must not be null");
-        Objects.requireNonNull(y, "y must not be null");
+    public ViewportSnapshot {
+        Objects.requireNonNull(minX, "minX must not be null");
+        Objects.requireNonNull(maxX, "maxX must not be null");
+        Objects.requireNonNull(minY, "minY must not be null");
+        Objects.requireNonNull(maxY, "maxY must not be null");
+        Objects.requireNonNull(cellSize, "cellSize must not be null");
     }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/VisibleWorldBounds.java
+++ b/src/main/java/com/mlprograms/justmath/graphing/fx/planar/view/VisibleWorldBounds.java
@@ -22,23 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
-import java.util.Objects;
-
-public enum ReservedVariables {
-
-    X("x"),
-    Y("y");
-
-    private final String value;
-
-    ReservedVariables(final String value) {
-        this.value = Objects.requireNonNull(value, "value must not be null");
-    }
-
-    public String getValue() {
-        return value;
-    }
-
+record VisibleWorldBounds(double minX, double maxX, double minY, double maxY) {
 }

--- a/src/test/java/com/mlprograms/justmath/graphing/fx/FxTestUtils.java
+++ b/src/test/java/com/mlprograms/justmath/graphing/fx/FxTestUtils.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx;
+package com.mlprograms.justmath.graphing.fx;
 
 public final class FxTestUtils {
 

--- a/src/test/java/com/mlprograms/justmath/graphing/fx/JavaFxRuntimeTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphing/fx/JavaFxRuntimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Max Lemberg
+ * Copyright (c) 2025-2026 Max Lemberg
  *
  * This file is part of JustMath.
  *
@@ -22,15 +22,10 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.model;
+package com.mlprograms.justmath.graphing.fx;
 
-import java.util.List;
-import java.util.Objects;
+class JavaFxRuntimeTest {
 
-public record PlotLine(List<PlotPoint> plotPoints) {
-
-    public PlotLine {
-        Objects.requireNonNull(plotPoints, "plotPoints must not be null");
-    }
+    // TODO
 
 }

--- a/src/test/java/com/mlprograms/justmath/graphing/fx/planar/view/GraphFxViewerTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphing/fx/planar/view/GraphFxViewerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Max Lemberg
+ * Copyright (c) 2025-2026 Max Lemberg
  *
  * This file is part of JustMath.
  *
@@ -22,20 +22,10 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
-import com.mlprograms.justmath.bignumber.BigNumber;
+class GraphFxViewerTest {
 
-import java.util.Objects;
-
-public record ViewportSnapshot(BigNumber minX, BigNumber maxX, BigNumber minY, BigNumber maxY, BigNumber cellSize) {
-
-    public ViewportSnapshot {
-        Objects.requireNonNull(minX, "minX must not be null");
-        Objects.requireNonNull(maxX, "maxX must not be null");
-        Objects.requireNonNull(minY, "minY must not be null");
-        Objects.requireNonNull(maxY, "maxY must not be null");
-        Objects.requireNonNull(cellSize, "cellSize must not be null");
-    }
+    // TODO
 
 }

--- a/src/test/java/com/mlprograms/justmath/graphing/fx/planar/view/GridPaneTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphing/fx/planar/view/GridPaneTest.java
@@ -22,9 +22,9 @@
  * SOFTWARE.
  */
 
-package com.mlprograms.justmath.graphfx.planar.view;
+package com.mlprograms.justmath.graphing.fx.planar.view;
 
-class GraphFxViewerTest {
+class GridPaneTest {
 
     // TODO
 


### PR DESCRIPTION
### Motivation
- Consolidate graphical components under a `graphing.fx` namespace to better reflect module responsibilities and improve package organization.
- Make runtime, view and calculator code for the Graph UI consistent with the existing `graphing` API surface.

### Description
- Moved classes from `com.mlprograms.justmath.graphfx...` to `com.mlprograms.justmath.graphing.fx...` and adjusted file locations accordingly.
- Relocated runtime/config classes `JavaFxRuntime`, `WindowConfig`, and `ReservedVariables`, and moved planar subpackages `calculator`, `model`, and `view` into `graphing.fx.planar`.
- Updated all package declarations and imports across `src/main` and `src/test` files, and updated `Main` to import `com.mlprograms.justmath.graphing.fx.planar.view.GraphFxViewer`.
- Moved test classes to matching `graphing.fx` package paths and moved the `spatial/TODO` placeholder under `graphing/fx/spatial`.

### Testing
- Ran targeted Maven command: `mvn -q -Dtest='com.mlprograms.justmath.graphing.fx.*Test,com.mlprograms.justmath.graphing.fx.planar.view.*Test,com.mlprograms.justmath.graphing.DefaultGraphingCalculatorTest' test`.
- Build aborted before tests due to an unresolved Maven build extension: `org.sonatype.central:central-publishing-maven-plugin:0.8.0` (artifact descriptor could not be resolved).
- No unit tests were executed because the build failed early; package/import changes were validated by updating source files and running file moves, and the repository changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2e82ceb1483339c6c19d673fa8ece)