### PR TITLE
Cache CalculatorEngine, fix thread-local variable handling, add plotting builders and thread-safe viewer updates

### DIFF
--- a/src/main/java/com/mlprograms/justmath/bignumber/BigNumber.java
+++ b/src/main/java/com/mlprograms/justmath/bignumber/BigNumber.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.mlprograms.justmath.bignumber.BigNumbers.DEFAULT_MATH_CONTEXT;
 import static com.mlprograms.justmath.bignumber.BigNumbers.ONE_HUNDRED_EIGHTY;
@@ -67,6 +68,7 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
      * This static parser ensures consistent parsing logic across all BigNumber instances.
      */
     private static final BigNumberParser bigNumberParser = new BigNumberParser();
+    private static final Map<TrigonometricMode, CalculatorEngine> CALCULATOR_ENGINE_CACHE = new ConcurrentHashMap<>();
     /**
      * The locale defining grouping and decimal separators used by this number.
      */
@@ -107,6 +109,10 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
     @NonNull
     @Setter
     private MathContext mathContext;
+
+    private static CalculatorEngine getCalculatorEngine(@NonNull final TrigonometricMode trigonometricMode) {
+        return CALCULATOR_ENGINE_CACHE.computeIfAbsent(trigonometricMode, CalculatorEngine::new);
+    }
 
     /**
      * Constructs a BigNumber from a string and locale using the default math context.
@@ -160,7 +166,7 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
         this.isNegative = parsedAndFormatted.isNegative;
         this.mathContext = mathContext;
         this.trigonometricMode = trigonometricMode;
-        this.calculatorEngine = new CalculatorEngine(trigonometricMode);
+        this.calculatorEngine = getCalculatorEngine(trigonometricMode);
     }
 
     /**
@@ -227,7 +233,7 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
 
         this.mathContext = mathContext;
         this.trigonometricMode = trigonometricMode;
-        this.calculatorEngine = new CalculatorEngine(trigonometricMode);
+        this.calculatorEngine = getCalculatorEngine(trigonometricMode);
     }
 
     /**
@@ -288,7 +294,7 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
         this.isNegative = bigNumber.isNegative;
         this.mathContext = mathContext;
         this.trigonometricMode = trigonometricMode;
-        this.calculatorEngine = new CalculatorEngine(trigonometricMode);
+        this.calculatorEngine = getCalculatorEngine(trigonometricMode);
     }
 
     /**
@@ -328,7 +334,7 @@ public class BigNumber extends Number implements Comparable<BigNumber> {
         this.isNegative = isNegative;
         this.mathContext = mathContext;
         this.trigonometricMode = trigonometricMode;
-        this.calculatorEngine = new CalculatorEngine(trigonometricMode);
+        this.calculatorEngine = getCalculatorEngine(trigonometricMode);
     }
 
     /**

--- a/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngine.java
+++ b/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngine.java
@@ -155,24 +155,28 @@ public class CalculatorEngine {
             return BigNumbers.ZERO;
         }
 
-        // Store the current variables in the thread-local storage
-        Map<String, String> combinedVariables = new HashMap<>(getCurrentVariables());
+        final Map<String, String> previousVariables = currentVariables.get();
+        final Map<String, String> combinedVariables = new HashMap<>(previousVariables);
         combinedVariables.putAll(variables);
         currentVariables.set(combinedVariables);
 
-        // Replace the |n| in the expression to look like abs(n)
-        String expressionWithoutAbsValueSign = replaceAbsSigns(expression);
+        try {
+            // Replace the |n| in the expression to look like abs(n)
+            String expressionWithoutAbsValueSign = replaceAbsSigns(expression);
 
-        // Tokenize the input string
-        List<Token> tokens = tokenizer.tokenize(expressionWithoutAbsValueSign);
+            // Tokenize the input string
+            List<Token> tokens = tokenizer.tokenize(expressionWithoutAbsValueSign);
 
-        replaceVariables(this, tokens, combinedVariables);
+            replaceVariables(this, tokens, combinedVariables);
 
-        // Parse to postfix notation using shunting yard algorithm
-        List<Token> postfix = postfixParser.toPostfix(tokens);
+            // Parse to postfix notation using shunting yard algorithm
+            List<Token> postfix = postfixParser.toPostfix(tokens);
 
-        // Evaluate the postfix expression to a BigDecimal result
-        return evaluator.evaluate(postfix).trim();
+            // Evaluate the postfix expression to a BigDecimal result
+            return evaluator.evaluate(postfix).trim();
+        } finally {
+            currentVariables.set(previousVariables);
+        }
     }
 
     /**

--- a/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngineUtils.java
+++ b/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngineUtils.java
@@ -143,22 +143,37 @@ public class CalculatorEngineUtils {
      */
     static void replaceVariables(@NonNull final CalculatorEngine calculatorEngine, @NonNull final List<Token> tokens, @NonNull final Map<String, String> variables) {
         checkVariablesForRecursion(calculatorEngine, variables);
+        final Map<String, String> resolvedVariables = new HashMap<>();
 
         for (int i = 0; i < tokens.size(); i++) {
             final Token token = tokens.get(i);
             if (token.getType() == Token.Type.VARIABLE) {
-                final String value = variables.get(token.getValue());
-
-                if (value == null || value.isBlank()) {
-                    throw new IllegalArgumentException("Variable '" + token.getValue() + "' is not defined.");
-                }
-
-                // Add zero to the evaluated variable value to coerce coordinate-style results into a single numeric value.
-                // Example: evaluated value = "r=5; θ=53.13010235" -> "(r=5; θ=53.13010235) + 0 = 5"
-                final String evaluatedVariableValue = calculatorEngine.evaluate(value, variables).add(BigNumbers.ZERO).toString();
+                final String evaluatedVariableValue = resolveVariable(calculatorEngine, token.getValue(), variables, resolvedVariables);
                 tokens.set(i, new Token(Token.Type.NUMBER, evaluatedVariableValue));
             }
         }
+    }
+
+    private static String resolveVariable(
+            @NonNull final CalculatorEngine calculatorEngine,
+            @NonNull final String variableName,
+            @NonNull final Map<String, String> variables,
+            @NonNull final Map<String, String> resolvedVariables
+    ) {
+        if (resolvedVariables.containsKey(variableName)) {
+            return resolvedVariables.get(variableName);
+        }
+
+        final String value = variables.get(variableName);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Variable '" + variableName + "' is not defined.");
+        }
+
+        // Add zero to the evaluated variable value to coerce coordinate-style results into a single numeric value.
+        // Example: evaluated value = "r=5; θ=53.13010235" -> "(r=5; θ=53.13010235) + 0 = 5"
+        final String evaluatedVariableValue = calculatorEngine.evaluate(value, variables).add(BigNumbers.ZERO).toString();
+        resolvedVariables.put(variableName, evaluatedVariableValue);
+        return evaluatedVariableValue;
     }
 
     static void checkVariablesForRecursion(@NonNull final CalculatorEngine calculatorEngine, @NonNull final Map<String, String> variables) {

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotLine.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotLine.java
@@ -23,6 +23,9 @@
  */
 package com.mlprograms.justmath.graphfx.planar.model;
 
+import lombok.NonNull;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,5 +48,15 @@ public record PlotLine(
      */
     public PlotLine {
         Objects.requireNonNull(plotPoints, "plotPoints must not be null");
+    }
+
+    /**
+     * Convenience factory for creating a line from vararg points.
+     *
+     * @param points points in world coordinates
+     * @return new plot line
+     */
+    public static PlotLine of(@NonNull final PlotPoint... points) {
+        return new PlotLine(Arrays.asList(points));
     }
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotPoint.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotPoint.java
@@ -24,7 +24,9 @@
 package com.mlprograms.justmath.graphfx.planar.model;
 
 import com.mlprograms.justmath.bignumber.BigNumber;
+import lombok.NonNull;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -52,5 +54,28 @@ public record PlotPoint(
     public PlotPoint {
         Objects.requireNonNull(x, "x must not be null");
         Objects.requireNonNull(y, "y must not be null");
+    }
+
+    /**
+     * Convenience factory for creating a point from primitive values.
+     *
+     * @param x x-coordinate in world units
+     * @param y y-coordinate in world units
+     * @return new plot point
+     */
+    public static PlotPoint of(final double x, final double y) {
+        return of(x, y, Locale.ROOT);
+    }
+
+    /**
+     * Convenience factory for creating a point from primitive values with a specific locale.
+     *
+     * @param x x-coordinate in world units
+     * @param y y-coordinate in world units
+     * @param locale locale used to create {@link BigNumber} coordinates
+     * @return new plot point
+     */
+    public static PlotPoint of(final double x, final double y, @NonNull final Locale locale) {
+        return new PlotPoint(new BigNumber(String.valueOf(x), locale), new BigNumber(String.valueOf(y), locale));
     }
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotResult.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotResult.java
@@ -24,6 +24,7 @@
 package com.mlprograms.justmath.graphfx.planar.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -66,5 +67,44 @@ public record PlotResult(
     public PlotResult {
         Objects.requireNonNull(plotPoints, "plotPoints must not be null");
         Objects.requireNonNull(plotLines, "plotLines must not be null");
+    }
+
+    /**
+     * Creates a fluent builder for plot results.
+     *
+     * @return new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent builder that reduces boilerplate when adding points and lines.
+     */
+    public static final class Builder {
+        private final List<PlotPoint> plotPoints = new ArrayList<>();
+        private final List<PlotLine> plotLines = new ArrayList<>();
+
+        public Builder addPoint(final PlotPoint plotPoint) {
+            plotPoints.add(Objects.requireNonNull(plotPoint, "plotPoint must not be null"));
+            return this;
+        }
+
+        public Builder addPoint(final double x, final double y) {
+            return addPoint(PlotPoint.of(x, y));
+        }
+
+        public Builder addLine(final PlotLine plotLine) {
+            plotLines.add(Objects.requireNonNull(plotLine, "plotLine must not be null"));
+            return this;
+        }
+
+        public Builder addLine(final PlotPoint... points) {
+            return addLine(new PlotLine(Arrays.asList(points)));
+        }
+
+        public PlotResult build() {
+            return new PlotResult(new ArrayList<>(plotPoints), new ArrayList<>(plotLines));
+        }
     }
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GraphFxViewer.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GraphFxViewer.java
@@ -26,12 +26,16 @@ package com.mlprograms.justmath.graphfx.planar.view;
 import com.mlprograms.justmath.graphfx.JavaFxRuntime;
 import com.mlprograms.justmath.graphfx.WindowConfig;
 import com.mlprograms.justmath.graphfx.planar.model.PlotResult;
+import com.mlprograms.justmath.graphfx.planar.model.PlotLine;
+import com.mlprograms.justmath.graphfx.planar.model.PlotPoint;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import lombok.Getter;
 
 import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Public entry point for the planar GraphFx GUI.
@@ -80,6 +84,8 @@ public final class GraphFxViewer {
      * Internal rendering surface responsible for drawing and interactions.
      */
     private final GraphFxPlotSurface plotSurface;
+    private final Object plotDataLock = new Object();
+    private PlotResult currentPlotResult = new PlotResult();
 
     /**
      * Lazily created JavaFX stage.
@@ -162,15 +168,78 @@ public final class GraphFxViewer {
      */
     public void setPlotResult(final PlotResult plotResult) {
         Objects.requireNonNull(plotResult, "plotResult must not be null");
+        synchronized (plotDataLock) {
+            currentPlotResult = new PlotResult(new ArrayList<>(plotResult.plotPoints()), new ArrayList<>(plotResult.plotLines()));
+        }
 
         JavaFxRuntime.ensureStarted();
         JavaFxRuntime.runOnFxThread(() -> plotSurface.setPlotResult(plotResult));
     }
 
     /**
+     * Adds a single point to the current plot and updates the viewer.
+     *
+     * @param point plot point to add
+     * @return this viewer instance for fluent usage
+     */
+    public GraphFxViewer addPoint(final PlotPoint point) {
+        Objects.requireNonNull(point, "point must not be null");
+        PlotResult updatedResult;
+
+        synchronized (plotDataLock) {
+            final List<PlotPoint> points = new ArrayList<>(currentPlotResult.plotPoints());
+            points.add(point);
+            updatedResult = new PlotResult(points, new ArrayList<>(currentPlotResult.plotLines()));
+            currentPlotResult = updatedResult;
+        }
+
+        final PlotResult resultToRender = updatedResult;
+        JavaFxRuntime.ensureStarted();
+        JavaFxRuntime.runOnFxThread(() -> plotSurface.setPlotResult(resultToRender));
+        return this;
+    }
+
+    /**
+     * Adds a single point (primitive coordinates) to the current plot and updates the viewer.
+     */
+    public GraphFxViewer addPoint(final double x, final double y) {
+        return addPoint(PlotPoint.of(x, y));
+    }
+
+    /**
+     * Adds a line to the current plot and updates the viewer.
+     */
+    public GraphFxViewer addLine(final PlotLine line) {
+        Objects.requireNonNull(line, "line must not be null");
+        PlotResult updatedResult;
+
+        synchronized (plotDataLock) {
+            final List<PlotLine> lines = new ArrayList<>(currentPlotResult.plotLines());
+            lines.add(line);
+            updatedResult = new PlotResult(new ArrayList<>(currentPlotResult.plotPoints()), lines);
+            currentPlotResult = updatedResult;
+        }
+
+        final PlotResult resultToRender = updatedResult;
+        JavaFxRuntime.ensureStarted();
+        JavaFxRuntime.runOnFxThread(() -> plotSurface.setPlotResult(resultToRender));
+        return this;
+    }
+
+    /**
+     * Adds a line from vararg points to the current plot and updates the viewer.
+     */
+    public GraphFxViewer addLine(final PlotPoint... points) {
+        return addLine(PlotLine.of(points));
+    }
+
+    /**
      * Clears all plot data.
      */
     public void clearPlot() {
+        synchronized (plotDataLock) {
+            currentPlotResult = new PlotResult();
+        }
         JavaFxRuntime.ensureStarted();
         JavaFxRuntime.runOnFxThread(plotSurface::clearPlot);
     }

--- a/src/test/java/com/mlprograms/justmath/calculator/CalculatorEnginePerformanceSmokeTest.java
+++ b/src/test/java/com/mlprograms/justmath/calculator/CalculatorEnginePerformanceSmokeTest.java
@@ -1,0 +1,26 @@
+package com.mlprograms.justmath.calculator;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class CalculatorEnginePerformanceSmokeTest {
+
+    @Test
+    void repeatedVariableReferencesAreEvaluatedWithinReasonableTime() {
+        CalculatorEngine engine = new CalculatorEngine();
+        Map<String, String> variables = Map.of(
+                "a", "sqrt(2)+sqrt(3)+sqrt(5)",
+                "b", "a+a+a+a+a+a+a+a+a+a"
+        );
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            for (int i = 0; i < 100; i++) {
+                engine.evaluate("b+b+b+b+b+b+b+b+b+b", variables);
+            }
+        });
+    }
+}

--- a/src/test/java/com/mlprograms/justmath/calculator/CalculatorEngineTest.java
+++ b/src/test/java/com/mlprograms/justmath/calculator/CalculatorEngineTest.java
@@ -228,6 +228,17 @@ public class CalculatorEngineTest {
         assertEquals(expectedResult, actualResult);
     }
 
+    @Test
+    void evaluateRestoresThreadLocalVariableContext() {
+        CalculatorEngine engine = new CalculatorEngine();
+
+        engine.evaluate("x+1", Map.of("x", "4"));
+        assertTrue(CalculatorEngine.getCurrentVariables().isEmpty());
+
+        engine.evaluate("2+2");
+        assertTrue(CalculatorEngine.getCurrentVariables().isEmpty());
+    }
+
     @ParameterizedTest
     @CsvSource(value = {
             // --- Einfache Durchschnittsberechnungen ---

--- a/src/test/java/com/mlprograms/justmath/graphfx/planar/model/PlotResultBuilderTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphfx/planar/model/PlotResultBuilderTest.java
@@ -1,0 +1,21 @@
+package com.mlprograms.justmath.graphfx.planar.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlotResultBuilderTest {
+
+    @Test
+    void builderAddsPointsAndLines() {
+        PlotResult result = PlotResult.builder()
+                .addPoint(1.5, 2.5)
+                .addPoint(PlotPoint.of(3, 4))
+                .addLine(PlotPoint.of(0, 0), PlotPoint.of(1, 1), PlotPoint.of(2, 1))
+                .build();
+
+        assertEquals(2, result.plotPoints().size());
+        assertEquals(1, result.plotLines().size());
+        assertEquals(3, result.plotLines().get(0).plotPoints().size());
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid creating redundant `CalculatorEngine` instances per `BigNumber` and ensure consistent behavior per `TrigonometricMode` by reusing engines. 
- Prevent leakage of thread-local variable context during expression evaluation and make variable evaluation resistant to repeated/recursive resolution. 
- Provide ergonomic APIs for plot data construction and make the JavaFX viewer safe to update from multiple threads.

### Description
- Added a `ConcurrentHashMap`-backed cache `CALCULATOR_ENGINE_CACHE` and `getCalculatorEngine` in `BigNumber` and switched constructors to reuse cached `CalculatorEngine` instances. 
- Modified `CalculatorEngine.evaluate` to capture the previous `currentVariables`, use them while evaluating, and restore the prior context in a `finally` block to avoid thread-local leakage. 
- Reworked `CalculatorEngineUtils.replaceVariables` to memoize resolved variables via `resolveVariable`, throw on undefined variables, and avoid repeated re-evaluation of the same variable during token replacement. 
- Extended plotting model types with convenience factories and builders: added `PlotLine.of(...)`, `PlotPoint.of(...)`, and `PlotResult.Builder` for easier construction. 
- Made `GraphFxViewer` maintain a synchronized `currentPlotResult` and added thread-safe `setPlotResult`, `addPoint`, `addLine`, and `clearPlot` operations that post updates to the JavaFX thread. 
- Small imports and test adjustments to wire the new APIs into the test suite.

### Testing
- Ran `CalculatorEngineTest` (including the new `evaluateRestoresThreadLocalVariableContext`) and all assertions passed. 
- Executed the new `CalculatorEnginePerformanceSmokeTest` to ensure repeated variable references evaluate within the time budget and it succeeded. 
- Executed `PlotResultBuilderTest` verifying builder and factory helpers and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b5c7ad788333a5a9cf3198324bfa)