### PR TITLE
Improve GraphFx usability and optimize calculator variable evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,21 @@ System.out.println(result);
 
 GraphFx is available as the JavaFX-based plotting layer in JustMath.
 
+Simple API example:
+
+```java
+GraphFxViewer viewer = new GraphFxViewer("GraphFx Demo");
+viewer.show();
+
+viewer.addPoint(0, 0);
+viewer.addLine(-2, -1, 0, 2, 2, -1);
+viewer.plotExpression("sin(x)");
+```
+
+Recent performance improvements:
+- reduced repeated variable re-evaluation in the `CalculatorEngine`
+- proper cleanup of evaluation context state to avoid stale thread-local variables between calls
+
 For the upcoming modular, library-first graphing calculator architecture (headless + GUI mode, MVC split, caching, adaptive sampling, and migration phases), see:
 
 - [`docs/graphing-calculator-architecture-plan.md`](docs/graphing-calculator-architecture-plan.md)

--- a/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngine.java
+++ b/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngine.java
@@ -168,24 +168,30 @@ public class CalculatorEngine {
             return BigNumbers.ZERO;
         }
 
+        final Map<String, String> previousVariables = currentVariables.get();
+
         // Store the current variables in the thread-local storage
-        Map<String, String> combinedVariables = new HashMap<>(getCurrentVariables());
+        final Map<String, String> combinedVariables = new HashMap<>(previousVariables);
         combinedVariables.putAll(variables);
         currentVariables.set(combinedVariables);
 
-        // Replace the |n| in the expression to look like abs(n)
-        String expressionWithoutAbsValueSign = replaceAbsSigns(expression);
+        try {
+            // Replace the |n| in the expression to look like abs(n)
+            final String expressionWithoutAbsValueSign = replaceAbsSigns(expression);
 
-        // Tokenize the input string
-        List<Token> tokens = tokenizer.tokenize(expressionWithoutAbsValueSign);
+            // Tokenize the input string
+            final List<Token> tokens = tokenizer.tokenize(expressionWithoutAbsValueSign);
 
-        replaceVariables(this, tokens, combinedVariables);
+            replaceVariables(this, tokens, combinedVariables, new HashMap<>());
 
-        // Parse to postfix notation using shunting yard algorithm
-        List<Token> postfix = postfixParser.toPostfix(tokens);
+            // Parse to postfix notation using shunting yard algorithm
+            final List<Token> postfix = postfixParser.toPostfix(tokens);
 
-        // Evaluate the postfix expression to a BigDecimal result
-        return evaluator.evaluate(postfix).trim();
+            // Evaluate the postfix expression to a BigDecimal result
+            return evaluator.evaluate(postfix).trim();
+        } finally {
+            currentVariables.set(previousVariables);
+        }
     }
 
     /**

--- a/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngineUtils.java
+++ b/src/main/java/com/mlprograms/justmath/calculator/CalculatorEngineUtils.java
@@ -139,7 +139,7 @@ public class CalculatorEngineUtils {
      * @param variables a map of variable names with their BigNumber values
      * @throws IllegalArgumentException if a variable token does not have a corresponding value in the map
      */
-    static void replaceVariables(@NonNull final CalculatorEngine calculatorEngine, @NonNull final List<Token> tokens, @NonNull final Map<String, String> variables) {
+    static void replaceVariables(@NonNull final CalculatorEngine calculatorEngine, @NonNull final List<Token> tokens, @NonNull final Map<String, String> variables, @NonNull final Map<String, String> resolvedVariablesCache) {
         checkVariablesForRecursion(calculatorEngine, variables);
 
         for (int i = 0; i < tokens.size(); i++) {
@@ -153,7 +153,10 @@ public class CalculatorEngineUtils {
 
                 // Add zero to the evaluated variable value to coerce coordinate-style results into a single numeric value.
                 // Example: evaluated value = "r=5; θ=53.13010235" -> "(r=5; θ=53.13010235) + 0 = 5"
-                final String evaluatedVariableValue = calculatorEngine.evaluate(value, variables).add(BigNumbers.ZERO).toString();
+                final String evaluatedVariableValue = resolvedVariablesCache.computeIfAbsent(
+                        token.getValue(),
+                        ignored -> calculatorEngine.evaluate(value, variables).add(BigNumbers.ZERO).toString()
+                );
                 tokens.set(i, new Token(Token.Type.NUMBER, evaluatedVariableValue));
             }
         }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotLine.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotLine.java
@@ -24,6 +24,7 @@
 
 package com.mlprograms.justmath.graphfx.planar.model;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -31,6 +32,34 @@ public record PlotLine(List<PlotPoint> plotPoints) {
 
     public PlotLine {
         Objects.requireNonNull(plotPoints, "plotPoints must not be null");
+        plotPoints = List.copyOf(plotPoints);
+    }
+
+    public static PlotLine of(final List<PlotPoint> plotPoints) {
+        return new PlotLine(plotPoints);
+    }
+
+    public static PlotLine of(final PlotPoint... plotPoints) {
+        Objects.requireNonNull(plotPoints, "plotPoints must not be null");
+        return new PlotLine(Arrays.asList(plotPoints));
+    }
+
+    public static PlotLine between(final PlotPoint first, final PlotPoint second) {
+        return new PlotLine(List.of(first, second));
+    }
+
+    public static PlotLine fromDoubles(final double... coordinates) {
+        Objects.requireNonNull(coordinates, "coordinates must not be null");
+        if (coordinates.length < 4 || coordinates.length % 2 != 0) {
+            throw new IllegalArgumentException("coordinates must contain pairs of x,y values and at least two points");
+        }
+
+        final PlotPoint[] points = new PlotPoint[coordinates.length / 2];
+        for (int i = 0, j = 0; i < coordinates.length; i += 2, j++) {
+            points[j] = PlotPoint.of(coordinates[i], coordinates[i + 1]);
+        }
+
+        return PlotLine.of(points);
     }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotPoint.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotPoint.java
@@ -35,4 +35,16 @@ public record PlotPoint(BigNumber x, BigNumber y) {
         Objects.requireNonNull(y, "y must not be null");
     }
 
+    public static PlotPoint of(final BigNumber x, final BigNumber y) {
+        return new PlotPoint(x, y);
+    }
+
+    public static PlotPoint of(final double x, final double y) {
+        return new PlotPoint(new BigNumber(Double.toString(x)), new BigNumber(Double.toString(y)));
+    }
+
+    public static PlotPoint of(final String x, final String y) {
+        return new PlotPoint(new BigNumber(x), new BigNumber(y));
+    }
+
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotResult.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/model/PlotResult.java
@@ -31,12 +31,34 @@ import java.util.Objects;
 public record PlotResult(List<PlotPoint> plotPoints, List<PlotLine> plotLines) {
 
     public PlotResult() {
-        this(new ArrayList<>(), new ArrayList<>());
+        this(List.of(), List.of());
     }
 
     public PlotResult {
         Objects.requireNonNull(plotPoints, "plotPoints must not be null");
         Objects.requireNonNull(plotLines, "plotLines must not be null");
+        plotPoints = List.copyOf(plotPoints);
+        plotLines = List.copyOf(plotLines);
+    }
+
+    public static PlotResult ofLine(final PlotLine plotLine) {
+        return new PlotResult(List.of(), List.of(plotLine));
+    }
+
+    public static PlotResult ofPoint(final PlotPoint plotPoint) {
+        return new PlotResult(List.of(plotPoint), List.of());
+    }
+
+    public PlotResult withLine(final PlotLine plotLine) {
+        final List<PlotLine> lines = new ArrayList<>(plotLines);
+        lines.add(plotLine);
+        return new PlotResult(plotPoints, lines);
+    }
+
+    public PlotResult withPoint(final PlotPoint plotPoint) {
+        final List<PlotPoint> points = new ArrayList<>(plotPoints);
+        points.add(plotPoint);
+        return new PlotResult(points, plotLines);
     }
 
 }

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GraphFxViewer.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GraphFxViewer.java
@@ -27,12 +27,15 @@ package com.mlprograms.justmath.graphfx.planar.view;
 import com.mlprograms.justmath.graphfx.JavaFxRuntime;
 import com.mlprograms.justmath.graphfx.WindowConfig;
 import com.mlprograms.justmath.graphfx.planar.calculator.GraphFxCalculatorEngine;
+import com.mlprograms.justmath.graphfx.planar.model.PlotLine;
+import com.mlprograms.justmath.graphfx.planar.model.PlotPoint;
 import com.mlprograms.justmath.graphfx.planar.model.PlotResult;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -80,6 +83,39 @@ public final class GraphFxViewer {
 
     public void plotExpression(final String expression) {
         plotExpression(expression, Map.of());
+    }
+
+    public void addPoint(final PlotPoint plotPoint) {
+        Objects.requireNonNull(plotPoint, "plotPoint must not be null");
+        JavaFxRuntime.ensureStarted();
+        JavaFxRuntime.runOnFxThread(() -> gridPane.addPlotPoint(plotPoint));
+    }
+
+    public void addPoint(final double x, final double y) {
+        addPoint(PlotPoint.of(x, y));
+    }
+
+    public void addLine(final PlotLine plotLine) {
+        Objects.requireNonNull(plotLine, "plotLine must not be null");
+        JavaFxRuntime.ensureStarted();
+        JavaFxRuntime.runOnFxThread(() -> gridPane.addPlotLine(plotLine));
+    }
+
+    public void addLine(final PlotPoint... plotPoints) {
+        addLine(PlotLine.of(plotPoints));
+    }
+
+    public void addLine(final List<PlotPoint> plotPoints) {
+        addLine(PlotLine.of(plotPoints));
+    }
+
+    public void addLine(final double... coordinates) {
+        addLine(PlotLine.fromDoubles(coordinates));
+    }
+
+    public void clear() {
+        JavaFxRuntime.ensureStarted();
+        JavaFxRuntime.runOnFxThread(gridPane::clearPlot);
     }
 
     public void plotExpression(final String expression, final Map<String, String> variables) {

--- a/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GridPane.java
+++ b/src/main/java/com/mlprograms/justmath/graphfx/planar/view/GridPane.java
@@ -183,6 +183,11 @@ final class GridPane extends Pane {
     }
 
     private void drawPlotResult(final GraphicsContext graphicsContext, final double width, final double height, final PlotResult plotResult) {
+        final List<PlotPoint> points = plotResult.plotPoints();
+        if (!points.isEmpty()) {
+            drawPoints(graphicsContext, width, height, points);
+        }
+
         final List<PlotLine> lines = plotResult.plotLines();
         if (lines.isEmpty()) {
             return;
@@ -198,6 +203,26 @@ final class GridPane extends Pane {
 
             graphicsContext.setStroke(Color.rgb(30, 30, 200));
             drawPolyline(graphicsContext, width, height, points);
+        }
+    }
+
+
+    private void drawPoints(final GraphicsContext graphics, final double width, final double height, final List<PlotPoint> points) {
+        graphics.setFill(Color.rgb(200, 30, 30));
+        final double radius = 3.0;
+
+        for (final PlotPoint point : points) {
+            final double worldX = point.x().doubleValue();
+            final double worldY = point.y().doubleValue();
+
+            if (!isFinite(worldX) || !isFinite(worldY)) {
+                continue;
+            }
+
+            final double screenX = worldToScreenX(worldX, scale, offsetX, width);
+            final double screenY = worldToScreenY(worldY, scale, offsetY, height);
+
+            graphics.fillOval(screenX - radius, screenY - radius, radius * 2.0, radius * 2.0);
         }
     }
 
@@ -453,6 +478,14 @@ final class GridPane extends Pane {
     void addPlotResult(final PlotResult plotResult) {
         this.plotResults.add(Objects.requireNonNull(plotResult, "plotResult must not be null"));
         redraw();
+    }
+
+    void addPlotLine(final PlotLine plotLine) {
+        addPlotResult(PlotResult.ofLine(plotLine));
+    }
+
+    void addPlotPoint(final PlotPoint plotPoint) {
+        addPlotResult(PlotResult.ofPoint(plotPoint));
     }
 
     void clearPlot() {

--- a/src/test/java/com/mlprograms/justmath/calculator/CalculatorEnginePerformanceRegressionTest.java
+++ b/src/test/java/com/mlprograms/justmath/calculator/CalculatorEnginePerformanceRegressionTest.java
@@ -1,0 +1,30 @@
+package com.mlprograms.justmath.calculator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CalculatorEnginePerformanceRegressionTest {
+
+    @Test
+    void evaluateCleansUpThreadLocalVariablesAfterCall() {
+        final CalculatorEngine engine = new CalculatorEngine();
+
+        engine.evaluate("a+1", Map.of("a", "41"));
+
+        assertTrue(CalculatorEngine.getCurrentVariables().isEmpty());
+    }
+
+    @Test
+    void nestedVariableEvaluationStillWorksWithCleanup() {
+        final CalculatorEngine engine = new CalculatorEngine();
+
+        final String result = engine.evaluate("a+b", Map.of("a", "2", "b", "a+3")).toString();
+
+        assertEquals("7", result);
+        assertTrue(CalculatorEngine.getCurrentVariables().isEmpty());
+    }
+}

--- a/src/test/java/com/mlprograms/justmath/graphfx/planar/model/PlotModelFactoriesTest.java
+++ b/src/test/java/com/mlprograms/justmath/graphfx/planar/model/PlotModelFactoriesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025-2026 Max Lemberg
+ */
+package com.mlprograms.justmath.graphfx.planar.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlotModelFactoriesTest {
+
+    @Test
+    void plotPointFactoriesCreateExpectedPoints() {
+        assertEquals("1.5", PlotPoint.of(1.5, 2.5).x().toString());
+        assertEquals("2.5", PlotPoint.of(1.5, 2.5).y().toString());
+
+        final PlotPoint point = PlotPoint.of("3", "4");
+        assertEquals("3", point.x().toString());
+        assertEquals("4", point.y().toString());
+    }
+
+    @Test
+    void plotLineFromDoublesCreatesPolyline() {
+        final PlotLine line = PlotLine.fromDoubles(0, 0, 1, 1, 2, 3);
+        assertEquals(3, line.plotPoints().size());
+        assertEquals("2.0", line.plotPoints().get(2).x().toString());
+        assertEquals("3.0", line.plotPoints().get(2).y().toString());
+    }
+
+    @Test
+    void plotResultWithMethodsAppendWithoutMutating() {
+        final PlotResult base = new PlotResult();
+        final PlotResult withPoint = base.withPoint(PlotPoint.of(1, 2));
+        final PlotResult withLine = withPoint.withLine(PlotLine.between(PlotPoint.of(0, 0), PlotPoint.of(1, 1)));
+
+        assertTrue(base.plotPoints().isEmpty());
+        assertTrue(base.plotLines().isEmpty());
+        assertEquals(1, withLine.plotPoints().size());
+        assertEquals(1, withLine.plotLines().size());
+    }
+
+    @Test
+    void plotLineAndResultDefensivelyCopyInputLists() {
+        final List<PlotPoint> mutablePoints = new ArrayList<>();
+        mutablePoints.add(PlotPoint.of(0, 0));
+
+        final PlotLine line = PlotLine.of(mutablePoints);
+        final PlotResult result = new PlotResult(mutablePoints, List.of(line));
+
+        mutablePoints.add(PlotPoint.of(10, 10));
+
+        assertEquals(1, line.plotPoints().size());
+        assertEquals(1, result.plotPoints().size());
+        assertThrows(UnsupportedOperationException.class, () -> line.plotPoints().add(PlotPoint.of(1, 1)));
+    }
+}


### PR DESCRIPTION
### Motivation

- Make the GraphFx viewer API easier to use so callers can add lines and points with minimal boilerplate and clearer helpers.
- Provide small model factory helpers and defensive immutability to improve developer ergonomics and avoid accidental list mutation.
- Eliminate performance and correctness issues around repeated variable evaluation and stale thread-local state in the calculator engine.

### Description

- Added ergonomic viewer API: `GraphFxViewer#addPoint(...)`, multiple `addLine(...)` overloads and `clear()` to directly add primitives to the view without manual `PlotResult` construction.
- Rendering & helpers: `GridPane` now renders standalone points and exposes `addPlotPoint(...)` / `addPlotLine(...)`; `PlotPoint`, `PlotLine` and `PlotResult` gained factory methods (`of`, `between`, `fromDoubles`, `ofPoint`, `ofLine`) and use `List.copyOf(...)` for defensive immutability.
- CalculatorEngine & utils: `CalculatorEngine.evaluate(...)` preserves and restores the thread-local variable context (`previousVariables`) in a `finally` block, and `CalculatorEngineUtils.replaceVariables(...)` now accepts a `resolvedVariablesCache` and caches resolved variable values via `computeIfAbsent(...)` to avoid duplicate evaluations.
- Tests & docs: added `PlotModelFactoriesTest` and `CalculatorEnginePerformanceRegressionTest` covering model factories, defensive copies and cleanup of thread-local variables; updated `README.md` with a short GraphFx usage example and notes about the performance improvements.

### Testing

- Attempted to run targeted tests with `mvn -q -Dtest=PlotModelFactoriesTest,CalculatorEnginePerformanceRegressionTest test` in the environment, but the Maven run failed due to an unresolvable build extension (`org.sonatype.central:central-publishing-maven-plugin:0.8.0`).
- Unit tests added and committed: `PlotModelFactoriesTest` and `CalculatorEnginePerformanceRegressionTest` (not executed successfully here due to the environment-level Maven plugin resolution error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c19af82c833394bc102f9f6b6bc6)